### PR TITLE
Display benchmark results as they become available

### DIFF
--- a/HashLib4CSharp.PerformanceBenchmark/PerformanceBenchmark.cs
+++ b/HashLib4CSharp.PerformanceBenchmark/PerformanceBenchmark.cs
@@ -71,11 +71,8 @@ namespace HashLib4CSharp.PerformanceBenchmark
         }
 
 
-        public static void DoBenchmark(ref List<string> logger)
+        public static IEnumerable<string> DoBenchmark()
         {
-            if (logger == null)
-                throw new ArgumentNullException(nameof(logger));
-
             var hashInstances = new List<IHash>();
 
             foreach (var type in typeof(HashFactory).GetNestedTypes(BindingFlags.Public))
@@ -94,7 +91,9 @@ namespace HashLib4CSharp.PerformanceBenchmark
 
             hashInstances.Add(HashFactory.Crypto.CreateBlake2BP(64, new byte[0]));
             hashInstances.Add(HashFactory.Crypto.CreateBlake2SP(32, new byte[0]));
-            logger.AddRange(hashInstances.Select(hash => Calculate(hash)));
+
+            foreach (var hash in hashInstances)
+                yield return Calculate(hash);
         }
     }
 }

--- a/HashLib4CSharp.PerformanceBenchmark/Program.cs
+++ b/HashLib4CSharp.PerformanceBenchmark/Program.cs
@@ -7,15 +7,12 @@ namespace HashLib4CSharp.PerformanceBenchmark
     {
         internal static void Main()
         {
-            var logger = new List<string>();
-
             Console.WriteLine("Please be patient, this might take some time \n\r");
 
             try
             {
-                PerformanceBenchmark.DoBenchmark(ref logger);
-
-                Console.WriteLine(string.Join("\n\r", logger));
+                foreach (var result in PerformanceBenchmark.DoBenchmark())
+                    Console.WriteLine(result);
 
                 Console.WriteLine("\n\rPerformance Benchmark Finished");
 


### PR DESCRIPTION
The old DoBenchmark() would fill in a list of the results, and Main()
would just dump the list. This makes the user wait for a long time
staring a blank screen that just asks them to be patient.

Since the benchmarking code is not dependent on anything that maybe
happening with the console I/O, DoBenchmark() has been change to return
an IEnumerable<string> and the result of each hashing benchmarking
result is yielded as they become available. This gives the user more
immediate feedback.