### PR TITLE
Use LINQ to search hashes to benchmark

### DIFF
--- a/HashLib4CSharp.PerformanceBenchmark/PerformanceBenchmark.cs
+++ b/HashLib4CSharp.PerformanceBenchmark/PerformanceBenchmark.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using HashLib4CSharp.Base;
 using HashLib4CSharp.Interfaces;
 
@@ -53,47 +54,47 @@ namespace HashLib4CSharp.PerformanceBenchmark
             return $"{newName} Throughput: {maxRate:0.00} MB/s with Blocks of {size / 1024} KB";
         }
 
-        private static void GetAllHashInstance(IReflect type, ref List<IHash> hashInstances)
+        private static IEnumerable<IHash> InstantiateHashes(IReflect type)
         {
             var methodInfos = type.GetMethods(BindingFlags.Public |
                                               BindingFlags.Static);
 
             var infos = methodInfos.Where(methodInfo =>
-                methodInfo.GetParameters().Length == 0 || methodInfo.GetParameters().All(parameterInfo =>
-                    parameterInfo.IsOptional));
+                methodInfo.GetParameters().Length == 0 ||
+                methodInfo.GetParameters().All(parameterInfo => parameterInfo.IsOptional));
 
-
-            hashInstances.AddRange(infos.Select(info => new {info, parameterInfos = info.GetParameters()})
-                .Select(t => ((IHash) t.info.Invoke(null,
+            return infos.Select(info => new { info, parameterInfos = info.GetParameters() })
+                .Select(t => ((IHash)t.info.Invoke(null,
                     t.parameterInfos.Length == 0
                         ? null
-                        : Enumerable.Repeat(Type.Missing, t.parameterInfos.Length).ToArray()))?.Clone()));
+                        : Enumerable.Repeat(Type.Missing, t.parameterInfos.Length).ToArray()))?.Clone());
         }
 
-
-        public static IEnumerable<string> DoBenchmark()
+        private static IEnumerable<IHash> GetAllHashInstances()
         {
-            var hashInstances = new List<IHash>();
+            return GetNestedTypesRecursively(typeof(HashFactory))
+                    .Where(t => t.IsClass && t.IsAbstract && t.IsSealed)
+                    .SelectMany(InstantiateHashes)
+                    .Concat(GetBlakeHashes());
 
-            foreach (var type in typeof(HashFactory).GetNestedTypes(BindingFlags.Public))
+            IEnumerable<Type> GetNestedTypesRecursively(Type root)
             {
-                if (!type.IsClass || !type.IsAbstract || !type.IsSealed) continue;
-
-                GetAllHashInstance(type, ref hashInstances);
-
-                foreach (var innerType in type.GetNestedTypes(BindingFlags.Public))
+                foreach(var type in root.GetNestedTypes(BindingFlags.Public))
                 {
-                    if (!innerType.IsClass || !innerType.IsAbstract || !innerType.IsSealed) continue;
-
-                    GetAllHashInstance(innerType, ref hashInstances);
+                    yield return type;
+                    foreach (var child in GetNestedTypesRecursively(type))
+                        yield return child;
                 }
             }
 
-            hashInstances.Add(HashFactory.Crypto.CreateBlake2BP(64, new byte[0]));
-            hashInstances.Add(HashFactory.Crypto.CreateBlake2SP(32, new byte[0]));
-
-            foreach (var hash in hashInstances)
-                yield return Calculate(hash);
+            IEnumerable<IHash> GetBlakeHashes()
+            {
+                yield return HashFactory.Crypto.CreateBlake2BP(64, new byte[0]);
+                yield return HashFactory.Crypto.CreateBlake2SP(32, new byte[0]);
+            }
         }
+
+        public static IEnumerable<string> DoBenchmark()
+            => GetAllHashInstances().Select(h => Calculate(h));
     }
 }


### PR DESCRIPTION
The code for finding the hash algorithms to benchmark was using the
procedural style of filling a list to be processed instead of the
modern C# functional style of consuming an IEnumerable. It was also
harder to discern what was actually being done to find them.

The refactored code use LINQ to surface the intent of the code:
- Recursively find all the types declared under the HashFactory class
- Pick only types that are abstract sealed classes
- Instantiate instances of these algorithms
- Also add some Blake2 algorithms