### PR TITLE
Use Span<T> for CRC32 computations

### DIFF
--- a/HashLib4CSharp/src/Checksum/CRC32Fast.cs
+++ b/HashLib4CSharp/src/Checksum/CRC32Fast.cs
@@ -12,7 +12,9 @@ for the purposes of supporting the XXX (https://YYY) project.
 */
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using HashLib4CSharp.Base;
 using HashLib4CSharp.Interfaces;
 using HashLib4CSharp.Utils;
@@ -40,8 +42,7 @@ namespace HashLib4CSharp.Checksum
             return result;
         }
 
-        protected unsafe void LocalCrcCompute(uint[][] crcTable, byte[] data, int index,
-            int length)
+        protected void LocalCrcCompute(uint[][] crcTable, byte[] data, int index, int length)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
             Debug.Assert(index >= 0);
@@ -50,69 +51,87 @@ namespace HashLib4CSharp.Checksum
 
             const int unroll = 4;
             const int bytesAtOnce = 16 * unroll;
+
             var crc = ~CurrentCRC;
+            var leftovers = BitConverter.IsLittleEndian ? ComputeLittleEndianBlocks()
+                                                        : ComputeBigEndianBlocks();
 
-            fixed (byte* dataPtr = data)
+            // remaining 1 to 63 bytes (standard algorithm)
+            foreach (var b in leftovers)
+                crc = (crc >> 8) ^ crcTable[0][(crc & 0xFF) ^ b];
+
+            CurrentCRC = ~crc;
+
+            ReadOnlySpan<byte> ComputeLittleEndianBlocks()
             {
-                var srcPtr = (uint*) (dataPtr + index);
-                while (length >= bytesAtOnce)
+                var dataSpan = data.AsSpan(index, length);
+                while (dataSpan.Length >= bytesAtOnce)
                 {
-                    var unrolling = 0;
-                    while (unrolling < unroll)
+                    var dataUints = MemoryMarshal.Cast<byte, uint>(dataSpan);
+                    for (int unrolling = 0; unrolling < unroll; unrolling++, dataUints = dataUints.Slice(4))
                     {
-                        var one = Converters.ReadPCardinalAsUInt32(srcPtr)
-                                  ^ Converters.le2me_32(crc);
-                        srcPtr++;
-                        var two = Converters.ReadPCardinalAsUInt32(srcPtr);
-                        srcPtr++;
-                        var three = Converters.ReadPCardinalAsUInt32(srcPtr);
-                        srcPtr++;
-                        var four = Converters.ReadPCardinalAsUInt32(srcPtr);
-                        srcPtr++;
+                        var one = dataUints[0] ^ crc;
+                        var two = dataUints[1];
+                        var three = dataUints[2];
+                        var four = dataUints[3];
 
-                        if (BitConverter.IsLittleEndian)
-                        {
-                            crc = crcTable[0][(four >> 24) & 0xFF] ^ crcTable[1]
-                                      [(four >> 16) & 0xFF] ^ crcTable[2][(four >> 8) & 0xFF]
-                                  ^ crcTable[3][four & 0xFF] ^ crcTable[4]
-                                      [(three >> 24) & 0xFF] ^ crcTable[5][(three >> 16) & 0xFF]
-                                  ^ crcTable[6][(three >> 8) & 0xFF] ^ crcTable[7]
-                                      [three & 0xFF] ^ crcTable[8][(two >> 24) & 0xFF] ^ crcTable
-                                      [9][(two >> 16) & 0xFF] ^ crcTable[10][(two >> 8) & 0xFF]
-                                  ^ crcTable[11][two & 0xFF] ^ crcTable[12][(one >> 24) & 0xFF]
-                                  ^ crcTable[13][(one >> 16) & 0xFF] ^ crcTable[14]
-                                      [(one >> 8) & 0xFF] ^ crcTable[15][one & 0xFF];
-                        }
-                        else
-                        {
-                            crc = crcTable[0][four & 0xFF] ^ crcTable[1]
-                                      [(four >> 8) & 0xFF] ^ crcTable[2][(four >> 16) & 0xFF]
-                                  ^ crcTable[3][(four >> 24) & 0xFF] ^ crcTable[4]
-                                      [three & 0xFF] ^ crcTable[5][(three >> 8) & 0xFF] ^ crcTable
-                                      [6][(three >> 16) & 0xFF] ^ crcTable[7][(three >> 24) & 0xFF]
-                                  ^ crcTable[8][two & 0xFF] ^ crcTable[9][(two >> 8) & 0xFF]
-                                  ^ crcTable[10][(two >> 16) & 0xFF] ^ crcTable[11]
-                                      [(two >> 24) & 0xFF] ^ crcTable[12][one & 0xFF] ^ crcTable
-                                      [13][(one >> 8) & 0xFF] ^ crcTable[14][(one >> 16) & 0xFF]
-                                  ^ crcTable[15][(one >> 24) & 0xFF];
-                        }
-
-                        unrolling++;
+                        crc = crcTable[0][(four >> 24) & 0xFF] ^
+                                crcTable[1][(four >> 16) & 0xFF] ^
+                                crcTable[2][(four >> 8) & 0xFF] ^
+                                crcTable[3][four & 0xFF] ^
+                                crcTable[4][(three >> 24) & 0xFF] ^
+                                crcTable[5][(three >> 16) & 0xFF] ^
+                                crcTable[6][(three >> 8) & 0xFF] ^
+                                crcTable[7][three & 0xFF] ^
+                                crcTable[8][(two >> 24) & 0xFF] ^
+                                crcTable[9][(two >> 16) & 0xFF] ^
+                                crcTable[10][(two >> 8) & 0xFF] ^
+                                crcTable[11][two & 0xFF] ^
+                                crcTable[12][(one >> 24) & 0xFF] ^
+                                crcTable[13][(one >> 16) & 0xFF] ^
+                                crcTable[14][(one >> 8) & 0xFF] ^
+                                crcTable[15][one & 0xFF];
                     }
 
-                    length -= bytesAtOnce;
+                    dataSpan = dataSpan.Slice(bytesAtOnce);
                 }
+                return dataSpan;
+            }
 
-                var srcPtr2 = (byte*) srcPtr;
-                // remaining 1 to 63 bytes (standard algorithm)
-                while (length != 0)
+            ReadOnlySpan<byte> ComputeBigEndianBlocks()
+            {
+                var dataSpan = data.AsSpan(index, length);
+                while (dataSpan.Length >= bytesAtOnce)
                 {
-                    crc = (crc >> 8) ^ crcTable[0][(crc & 0xFF) ^ *srcPtr2];
-                    srcPtr2++;
-                    length--;
-                }
+                    var dataUints = MemoryMarshal.Cast<byte, uint>(dataSpan);
+                    for (int unrolling = 0; unrolling < unroll; unrolling++, dataUints = dataUints.Slice(4))
+                    {
+                        var one = dataUints[0] ^ Bits.ReverseBytesUInt32(crc);
+                        var two = dataUints[1];
+                        var three = dataUints[2];
+                        var four = dataUints[3];
 
-                CurrentCRC = ~crc;
+                        crc = crcTable[0][four & 0xFF] ^
+                                crcTable[1][(four >> 8) & 0xFF] ^
+                                crcTable[2][(four >> 16) & 0xFF] ^
+                                crcTable[3][(four >> 24) & 0xFF] ^
+                                crcTable[4][three & 0xFF] ^
+                                crcTable[5][(three >> 8) & 0xFF] ^
+                                crcTable[6][(three >> 16) & 0xFF] ^
+                                crcTable[7][(three >> 24) & 0xFF] ^
+                                crcTable[8][two & 0xFF] ^
+                                crcTable[9][(two >> 8) & 0xFF] ^
+                                crcTable[10][(two >> 16) & 0xFF] ^
+                                crcTable[11][(two >> 24) & 0xFF] ^
+                                crcTable[12][one & 0xFF] ^
+                                crcTable[13][(one >> 8) & 0xFF] ^
+                                crcTable[14][(one >> 16) & 0xFF] ^
+                                crcTable[15][(one >> 24) & 0xFF];
+                    }
+
+                    dataSpan = dataSpan.Slice(bytesAtOnce);
+                }
+                return dataSpan;
             }
         }
 


### PR DESCRIPTION
The core of the CRC32 computations is marked as unsafe because it uses
pointers to try to efficiently process the blocks of memory. By
taking advantage of the newer Span<T> types, the need to use pointers
can be removed. Furthermore the code is made more legible with less
needs to take into account the current index and remaining lengths as
the data is scanned.

Also refactored the code to remove the two branches inside the tight
inner loop. The two branches checked the machine architecture to see
if the machine is little or big endian. Since this state will never
change at runtime (without a reboot), the check is done only once
outside the loop.