### PR TITLE
Improve Adler32 performance

### DIFF
--- a/HashLib4CSharp/src/Checksum/Adler32.cs
+++ b/HashLib4CSharp/src/Checksum/Adler32.cs
@@ -29,7 +29,7 @@ namespace HashLib4CSharp.Checksum
         {
         }
 
-        public override IHash Clone() => new Adler32 {_a = _a, _b = _b, BufferSize = BufferSize};
+        public override IHash Clone() => new Adler32 { _a = _a, _b = _b, BufferSize = BufferSize };
 
         public override void Initialize()
         {
@@ -55,28 +55,78 @@ namespace HashLib4CSharp.Checksum
 
             var a = _a;
             var b = _b;
-            while (length > 0)
+
+            // We can defer the modulo operation:
+            // a maximally grows from 65521 to 65521 + 255 * 3800
+            // b maximally grows by 3800 * median(a) = 2090079800 < 2^31
+            const int BigBlockSize = 3800;
+
+            var buffer = new ReadOnlySpan<byte>(data, index, length);
+            int bigBlockCount = buffer.Length / BigBlockSize;
+            if (Environment.Is64BitProcess)
             {
-                // We can defer the modulo operation:
-                // a maximally grows from 65521 to 65521 + 255 * 3800
-                // b maximally grows by 3800 * median(a) = 2090079800 < 2^31
-                var n = 3800;
-                if (n > length)
-                    n = length;
-
-                length -= n;
-
-                while (n - 1 >= 0)
+                while (bigBlockCount-- > 0)
                 {
-                    a += data[index];
-                    b += a;
-                    index++;
-                    n--;
-                }
+                    foreach (var word in MemoryMarshal.Cast<byte, UInt64>(buffer.Slice(0, BigBlockSize)))
+                    {
+                        var lo = (uint)word;
+                        a += lo & 0xFF;
+                        b += a;
 
-                a %= ModAdler;
-                b %= ModAdler;
+                        a += (lo >> 8) & 0xFF;
+                        b += a;
+
+                        a += (lo >> 16) & 0xFF;
+                        b += a;
+
+                        a += (lo >> 24) & 0xFF;
+                        b += a;
+
+                        var hi = (uint)(word >> 32);
+                        a += hi & 0xFF;
+                        b += a;
+
+                        a += (hi >> 8) & 0xFF;
+                        b += a;
+
+                        a += (hi >> 16) & 0xFF;
+                        b += a;
+
+                        a += (hi >> 24) & 0xFF;
+                        b += a;
+                    }
+
+                    a %= ModAdler;
+                    b %= ModAdler;
+
+                    buffer = buffer.Slice(BigBlockSize);
+                }
             }
+            else
+            {
+                while (bigBlockCount-- > 0)
+                {
+                    foreach (var value in buffer.Slice(0, BigBlockSize))
+                    {
+                        a += value;
+                        b += a;
+                    }
+
+                    a %= ModAdler;
+                    b %= ModAdler;
+
+                    buffer = buffer.Slice(BigBlockSize);
+                }
+            }
+
+            foreach (var value in buffer)
+            {
+                a += value;
+                b += a;
+            }
+
+            a %= ModAdler;
+            b %= ModAdler;
 
             _a = a;
             _b = b;


### PR DESCRIPTION
The previous version would repeatedly compute an offset into a byte
array. Furthermore it would repeatedly try to determine whether it is
processing the maximum of 3800 bytes during the current iteration,
or if it finally at the last few bytes of data.

Changed the logic to handle all the big blocks first.

Modified the code to use a ReadOnlySpan<byte>. Although the
ReadOnlySpan<byte>.Enumerator also computes an offset into a byte array,
it looks to be performing better at about 1100 MB/s as compared to the
original code running at 685 MB/s.

For code running in 64-bit processes, data is read from memory 64-bits
at a time while working on the big blocks to get an additional 200 MB/s
more throughput bringing the speed up to 1300 MB/s.