### PR TITLE
Use Regex to pick performance benchmark to run

### DIFF
--- a/HashLib4CSharp.PerformanceBenchmark/PerformanceBenchmark.cs
+++ b/HashLib4CSharp.PerformanceBenchmark/PerformanceBenchmark.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using HashLib4CSharp.Base;
 using HashLib4CSharp.Interfaces;
 
@@ -93,7 +94,11 @@ namespace HashLib4CSharp.PerformanceBenchmark
             }
         }
 
-        public static IEnumerable<string> DoBenchmark()
-            => GetAllHashInstances().Select(hash => Calculate(hash));
+        public static IEnumerable<string> DoBenchmark(IEnumerable<string> patterns)
+        {
+            return GetAllHashInstances()
+                    .Where(h => patterns.Any(p => Regex.IsMatch(h.Name, p)))
+                    .Select(hash => Calculate(hash));
+        }
     }
 }

--- a/HashLib4CSharp.PerformanceBenchmark/Program.cs
+++ b/HashLib4CSharp.PerformanceBenchmark/Program.cs
@@ -1,17 +1,25 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace HashLib4CSharp.PerformanceBenchmark
 {
     internal static class Program
     {
-        internal static void Main()
+        internal static void Main(string [] args)
         {
+            var patterns = new List<string>();
+            if (args?.Length > 0)
+                patterns.AddRange(args);
+            else
+                patterns.Add(".*");
+
+            Console.WriteLine("Benchmarking hashes whose names match: {0}", string.Join(", ", patterns.Select(s => $"'{s}'")));
             Console.WriteLine("Please be patient, this might take some time \n\r");
 
             try
             {
-                foreach (var result in PerformanceBenchmark.DoBenchmark())
+                foreach (var result in PerformanceBenchmark.DoBenchmark(patterns))
                     Console.WriteLine(result);
 
                 Console.WriteLine("\n\rPerformance Benchmark Finished");


### PR DESCRIPTION
Support choosing which benchmarks to run by passing in regex patterns
in the commandline.